### PR TITLE
Add setting API key without env vars

### DIFF
--- a/cryptocompare/cryptocompare.py
+++ b/cryptocompare/cryptocompare.py
@@ -11,6 +11,7 @@ Timestamp = Union[datetime.datetime, datetime.date, int, float]
 
 # API
 _API_KEY = None
+_API_KEY_PARAMETER = ""
 _URL_COIN_LIST = 'https://www.cryptocompare.com/api/data/coinlist?'
 _URL_PRICE = 'https://min-api.cryptocompare.com/data/pricemulti?fsyms={}&tsyms={}'
 _URL_PRICE_MULTI = 'https://min-api.cryptocompare.com/data/pricemulti?fsyms={}&tsyms={}'
@@ -78,14 +79,16 @@ def _format_timestamp(timestamp: Timestamp) -> int:
     return int(timestamp)
 
 def _set_api_key_parameter(api_key: str = None) -> str:
+    global _API_KEY
     _API_KEY = api_key
     
 def _get_api_key_parameter(api_key: str = None) -> str:
     if api_key is None:
         api_key = os.getenv('CRYPTOCOMPARE_API_KEY')
     if api_key is not None:
-        _API_KEY = "&api_key={}".format(api_key)
-        return _API_KEY
+        global _API_KEY_PARAMETER
+        _API_KEY_PARAMETER = "&api_key={}".format(api_key)
+        return _API_KEY_PARAMETER
     return ""
 
 ###############################################################################

--- a/cryptocompare/cryptocompare.py
+++ b/cryptocompare/cryptocompare.py
@@ -10,7 +10,7 @@ from typing import Union, Optional, List, Dict
 Timestamp = Union[datetime.datetime, datetime.date, int, float]
 
 # API
-_API_KEY_PARAMETER = ""
+_API_KEY = None
 _URL_COIN_LIST = 'https://www.cryptocompare.com/api/data/coinlist?'
 _URL_PRICE = 'https://min-api.cryptocompare.com/data/pricemulti?fsyms={}&tsyms={}'
 _URL_PRICE_MULTI = 'https://min-api.cryptocompare.com/data/pricemulti?fsyms={}&tsyms={}'
@@ -38,7 +38,9 @@ def _query_cryptocompare(url: str, errorCheck: bool = True, api_key: str = None)
     :returns: respones, or nothing if errorCheck=True
     :api_key: optional, if you want to add an API Key
     """
-    api_key_parameter = _set_api_key_parameter(api_key)
+    if api_key is None and _API_KEY is not None:
+        api_key = _API_KEY
+    api_key_parameter = _get_api_key_parameter(api_key)
     try:
         response = requests.get(url + api_key_parameter).json()
     except Exception as e:
@@ -75,8 +77,10 @@ def _format_timestamp(timestamp: Timestamp) -> int:
         return int(time.mktime(timestamp.timetuple()))
     return int(timestamp)
 
-
 def _set_api_key_parameter(api_key: str = None) -> str:
+    _API_KEY = api_key
+    
+def _get_api_key_parameter(api_key: str = None) -> str:
     if api_key is None:
         api_key = os.getenv('CRYPTOCOMPARE_API_KEY')
     if api_key is not None:


### PR DESCRIPTION
Add possibility to directly set the `_API_KEY` as a variable, renamed from the previously _unused_ `_API_KEY_PARAMETER`.

I renamed the inadequately named `_set_api_key_parameter()` to `_get_api_key_parameter()`. To stay in line with documentation, `_set_api_key_parameter()` has been replaced by a function which allows to set the protected `_API_KEY` variable, which is being used, in case no api_key has been passed to `_query_cryptocompare()`.

This will keep current code, relying on env vars still running, but enables setting the api_key without manipulating environment variables. In case _API_KEY is set, it will override any API keys set in env vars.

The code should now work as described on [https://pypi.org/project/cryptocompare/](https://pypi.org/project/cryptocompare/).